### PR TITLE
More room for screens wider than 1200px

### DIFF
--- a/public/styles/site.less
+++ b/public/styles/site.less
@@ -25,6 +25,10 @@
 // Add your own site style includes here
 @import "site/layout.less";
 
+// http://embedresponsively.com/ - Drop when we update bootstrapt to >= 3.2
+@import "site/embed.less";
+
+
 /*
 * Site wide
 */
@@ -142,7 +146,7 @@ a:focus,
 }
 
 .bg-hidden-mobile {
-  height: 350px;
+  height: 346px;
   background-size: 100% auto;
   background-color: #EEE;
   background-repeat: no-repeat;
@@ -264,7 +268,7 @@ span[style] {
     min-height: 600px;
     .galleria {
       max-width: 580px;
-      height: 80%;
+      height: 90%;
       min-height: 480px;
     }
   }
@@ -341,6 +345,7 @@ a {
     height: 100%;
     overflow: hidden;
     text-align: center;
+    white-space: nowrap;
   }
   html::before{
     display:inline-block;
@@ -353,6 +358,7 @@ a {
     display:inline-block;
     vertical-align:middle;
     text-align: left;
+    white-space:normal;
     width: 960px;
     height: 680px;
     background: white;
@@ -425,9 +431,6 @@ a {
   .home .content img, .homepageupdate .content img {
     min-height: 400px;
   }
-  .home .content iframe, .homepageupdate .content iframe {
-    height: 350px;
-  }
   .image-grid ul li .grid-image {
     width: 115px;
 
@@ -449,12 +452,12 @@ a {
     padding: 8px 0;
     /* "transparent" only works here because == rgba(0,0,0,0) */
     background: -moz-linear-gradient(top,  rgba(255,255,255,0) 0%, rgba(255,255,255,1) 100%); /* FF3.6+ */
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(255,255,255,0)), color-stop(100%,rgba(255,255,255,1))); /* Chrome,Safari4+ */
-  background: -webkit-linear-gradient(top,  rgba(255,255,255,0) 0%,rgba(255,255,255,1) 100%); /* Chrome10+,Safari5.1+ */
-  background: -o-linear-gradient(top,  rgba(255,255,255,0) 0%,rgba(255,255,255,1) 100%); /* Opera 11.10+ */
-  background: -ms-linear-gradient(top,  rgba(255,255,255,0) 0%,rgba(255,255,255,1) 100%); /* IE10+ */
-  background: linear-gradient(to bottom,  rgba(255,255,255,0) 0%,rgba(255,255,255,1) 100%); /* W3C */
-  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', endColorstr='#ffffff',GradientType=0 ); /* IE6-9 */
+    background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(255,255,255,0)), color-stop(100%,rgba(255,255,255,1))); /* Chrome,Safari4+ */
+    background: -webkit-linear-gradient(top,  rgba(255,255,255,0) 0%,rgba(255,255,255,1) 100%); /* Chrome10+,Safari5.1+ */
+    background: -o-linear-gradient(top,  rgba(255,255,255,0) 0%,rgba(255,255,255,1) 100%); /* Opera 11.10+ */
+    background: -ms-linear-gradient(top,  rgba(255,255,255,0) 0%,rgba(255,255,255,1) 100%); /* IE10+ */
+    background: linear-gradient(to bottom,  rgba(255,255,255,0) 0%,rgba(255,255,255,1) 100%); /* W3C */
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', endColorstr='#ffffff',GradientType=0 ); /* IE6-9 */
   }
   .col-right .content:not(.jspScrollable) .jspContainer {
     width: 570px !important;
@@ -633,17 +636,34 @@ a {
 }
 @media (min-width: @screen-lg-min) {
   body.container-fluid {
-    // margin-top: -390px;
-    width: 1100px;
-    height: 780px;
+    width: 1160px;
   }
-  body.container-fluid::before {
-    left: 378px;
+  .col-left {
+    width: 316px;
   }
-  .navbar-default {
-    left: 366px;
+  .col-right {
+    width: 840px;
+    padding-right: 10px;
   }
-  .col-right .content {
-    width: 686px;
+  .col-right .content:not(.jspScrollable) .jspContainer{
+    width:770px !important;
+  }
+  .col-right .content{
+    width: auto;
+    height:540px;
+  }
+  .image-grid ul li .grid-image {
+    width: 152px;
+    background-position:left center;
+  }
+  .project .col-right .project {
+    margin-top:-40px;
+  }
+  .project .col-right .project .galleria {
+    height:100%;
+    max-width: none;
+  }
+  .bg-hidden-mobile {
+    height:390px;
   }
 }

--- a/public/styles/site.less
+++ b/public/styles/site.less
@@ -29,7 +29,6 @@
 * Site wide
 */
 body {
-  position: relative;
   font-weight: 200;
 }
 
@@ -41,7 +40,7 @@ body {
   margin:-30px;
   background:#EEE;
   z-index: 9000;
-  
+
   .galleria {
     width: 100%;
     height: 680px;
@@ -229,7 +228,7 @@ a:hover {
       padding-left: 0;
     }
   }
-  
+
   img {
     max-width: 100%;
   }
@@ -341,18 +340,27 @@ a {
     background-color: #EEE;
     height: 100%;
     overflow: hidden;
+    text-align: center;
+  }
+  html::before{
+    display:inline-block;
+    content:'';
+    height:100%;
+    vertical-align:middle;
   }
   body.container-fluid {
-    top: 50%;
-    margin-top: -340px;
-    left: 50%;
-    margin-left: -480px;
-    position: absolute;
+    position: relative;
+    display:inline-block;
+    vertical-align:middle;
+    text-align: left;
     width: 960px;
     height: 680px;
     background: white;
     overflow: hidden;
     padding: 30px 0 30px 30px;
+    > .row {
+      height: calc(~"100% - 110px");
+    }
   }
   body::before {
     content: '';
@@ -371,24 +379,23 @@ a {
     width: 500px;
   }
   .col-left {
-    height: 620px;
+    height:100%;
   }
   ul.sidebar {
     width: 100%;
-    height: 520px;
+    height: 100%;
     overflow: hidden;
   }
   .col-right {
     position: static;
     padding-right: 0;
     min-height: 100%;
-  }
-  .col-right {
+    height:100%;
     padding-left: 30px;
   }
   .col-right .content {
     width: 595px;
-    height: 540px;
+    height: 100%;
   }
   .about .col-right .content {
     width: 580px;
@@ -434,13 +441,13 @@ a {
     overflow: hidden;
   }
   .image-grid h4 .fade-bottom {
-    position: absolute; 
+    position: absolute;
     bottom: 0; left: 0;
-    width: 100%; 
-    text-align: center; 
+    width: 100%;
+    text-align: center;
     margin: 0;
-    padding: 8px 0; 
-    /* "transparent" only works here because == rgba(0,0,0,0) */ 
+    padding: 8px 0;
+    /* "transparent" only works here because == rgba(0,0,0,0) */
     background: -moz-linear-gradient(top,  rgba(255,255,255,0) 0%, rgba(255,255,255,1) 100%); /* FF3.6+ */
   background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(255,255,255,0)), color-stop(100%,rgba(255,255,255,1))); /* Chrome,Safari4+ */
   background: -webkit-linear-gradient(top,  rgba(255,255,255,0) 0%,rgba(255,255,255,1) 100%); /* Chrome10+,Safari5.1+ */
@@ -622,5 +629,21 @@ a {
 @media all and (max-width: 500px) {
   button.navbar-toggle {
     margin-top: 0;
+  }
+}
+@media (min-width: @screen-lg-min) {
+  body.container-fluid {
+    // margin-top: -390px;
+    width: 1100px;
+    height: 780px;
+  }
+  body.container-fluid::before {
+    left: 378px;
+  }
+  .navbar-default {
+    left: 366px;
+  }
+  .col-right .content {
+    width: 686px;
   }
 }

--- a/public/styles/site/embed.less
+++ b/public/styles/site/embed.less
@@ -1,0 +1,16 @@
+.embed-container {
+   position: relative;
+   padding-bottom: 56.25%;
+   height: 0;
+   overflow: hidden;
+   max-width: 100%;
+ }
+.embed-container iframe,
+.embed-container object,
+.embed-container embed {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/templates/mixins/video-embed.jade
+++ b/templates/mixins/video-embed.jade
@@ -1,0 +1,8 @@
+mixin video-embed(update)
+  if !update
+    // do nothing
+  else if update.videoEmbed
+    .embed-container
+      != update.videoEmbed
+  else
+    .bg-hidden-mobile(style='background-image: url("'+ update._.image.fill(800, 600) + '");')

--- a/templates/views/homepageupdate.jade
+++ b/templates/views/homepageupdate.jade
@@ -1,12 +1,10 @@
 extends ../layouts/default
+include ../mixins/video-embed
 
 block content
   ul.list-unstyled.content
     li
-      if selectedUpdate.videoEmbed
-        != selectedUpdate.videoEmbed
-      else
-        .bg-hidden-mobile(style='background-image: url("'+ selectedUpdate._.image.fill(800, 600) + '");')
+      +video-embed(selectedUpdate)
       h3= selectedUpdate.title
       p!= selectedUpdate.content
 

--- a/templates/views/index.jade
+++ b/templates/views/index.jade
@@ -1,4 +1,5 @@
 extends ../layouts/default
+include ../mixins/video-embed
 
 block splash
   #splash
@@ -8,10 +9,7 @@ block content
   ul.list-unstyled.content
     each update in updates.slice(0,9)
       li
-        if update.videoEmbed
-          != update.videoEmbed
-        else
-          .bg-hidden-mobile(style='background-image: url("'+update._.image.fill(800, 600) + '");')
+        +video-embed(update)
         a(href='updates/' + update.slug)
           h3= update.title
         p!= update.excerpt
@@ -26,7 +24,7 @@ block sidebar
         a(href='updates/' + update.slug)
           .col-sm-6
             if update.image.url
-              img(src= update._.image.fill(350, 350))
+              img(src= update._.image.fill(400, 400))
             else if update.videoThumbnail
               img(src= update.videoThumbnail)
           .col-sm-6


### PR DESCRIPTION
Home page at 1366x768
<img width="1478" alt="screenshot 2015-07-13 23 05 58" src="https://cloud.githubusercontent.com/assets/58871/8662030/0a1c93ae-29b4-11e5-8e0a-a09f1feb5e42.png">

Responsive video embed preserves 16x9 youtube video iframe aspect ratio.
<img width="1478" alt="screenshot 2015-07-13 23 06 09" src="https://cloud.githubusercontent.com/assets/58871/8662052/3a4be084-29b4-11e5-98c3-08a351e2f6ba.png">

Project page thumbnails are wider (152px each) but no taller, else we drop off the bottom.
<img width="1478" alt="screenshot 2015-07-13 23 06 13" src="https://cloud.githubusercontent.com/assets/58871/8662067/515b5c6e-29b4-11e5-9f7f-6fee4881b19b.png">

Project page is given more vertical height, breaking the line with the text in the left hand column to maximise the vertical height available... (we could go closer to the nav, but it may start to look crowded.)
<img width="1478" alt="screenshot 2015-07-13 23 06 28" src="https://cloud.githubusercontent.com/assets/58871/8662101/9077133e-29b4-11e5-90d8-d81c73ae7866.png">

Portrait images have a little more room too.
<img width="1478" alt="screenshot 2015-07-13 23 06 50" src="https://cloud.githubusercontent.com/assets/58871/8662112/a66a7ed8-29b4-11e5-9b47-844bbfe96d47.png">
